### PR TITLE
bug: fix amcl parameters to make localization better

### DIFF
--- a/catkin_ws/src/my_robot/launch/amcl.launch
+++ b/catkin_ws/src/my_robot/launch/amcl.launch
@@ -17,28 +17,27 @@
     <param name="initial_pose_a" value="-1.5707"/> 
 
     <!-- SUGGESTED paramters -->
-    <param name="min_particles" value="50"/>  <!-- default: 100  TODO: feedback: reduce? -->
-    <param name="max_particles" value="100"/> <!-- default: 5000 TODO: feedback: reduce -->
+    <param name="min_particles" value="100"/>  <!-- default: 100; feedback: reduce? -->
+    <param name="max_particles" value="200"/> <!-- default: 5000;  feedback: reduce -->
     <param name="transform_tolerance" value="0.2"/> <!-- default:0.2 -->
-    <param name="odom_alpha1" value="0.2"/> <!-- default:0.2  TODO: feedback: add alphas-->
-    <param name="odom_alpha2" value="0.2"/> <!-- default:0.2  TODO: feedback: add alphas-->	
-    <param name="odom_alpha3" value="0.2"/> <!-- default:0.2  TODO: feedback: add alphas-->
-    <param name="odom_alpha4" value="0.2"/> <!-- default:0.2  TODO: feedback: add alphas-->
+    <param name="odom_alpha1" value="0.01"/> <!-- default:0.2; feedback: add alphas-->
+    <param name="odom_alpha2" value="0.01"/> <!-- default:0.2; feedback: add alphas-->	
+    <param name="odom_alpha3" value="0.01"/> <!-- default:0.2; feedback: add alphas-->
+    <param name="odom_alpha4" value="0.01"/> <!-- default:0.2; feedback: add alphas-->
 
     <!-- CUSTOM parameters: Laser -->
-    <param name="laser_min_range" value="-1.0"/>
-    <param name="laser_max_range" value="-1.0"/>
-    <param name="laser_min_beams" value="30"/>
+    <param name="laser_min_range" value="-1.0"/> <!-- default:-1.0 -->
+    <param name="laser_max_range" value="-1.0"/> <!-- default:-1.0 -->
+    <param name="laser_min_beams" value="30"/> <!-- default: 30 -->
     <param name="laser_model_type" value="likelihood_field"/>
     <!-- REMEMBER: laser_z_hit + laser_z_rand should sum 1.00 -->
-    <param name="laser_z_hit" value="0.95"/> <!-- default: 0.95  TODO: feedback: increase -->
-    <param name="laser_z_rand" value="0.05"/> <!-- default: 0.05  TODO: feedback: reduce? -->
+    <param name="laser_z_hit" value="0.97"/> <!-- default: 0.95; feedback: increase -->
+    <param name="laser_z_rand" value="0.03"/> <!-- default: 0.05; feedback: reduce? -->
 
   </node>
 
   <!-- OPTIONAL: Add Move Base Node -->
   <!-- Note that this step is optional if you choose to use teleop node to control and localize your robot. -->
-    <!-- (DISABLED: using teleop)
     <node name="move_base" pkg="move_base" type="move_base" respawn="false" output="screen">
     <remap from="scan" to="scan"/>
     <param name="base_global_planner" value="navfn/NavfnROS" />
@@ -49,6 +48,5 @@
   <rosparam file="$(find my_robot)/config/global_costmap_params.yaml" command="load" />
   <rosparam file="$(find my_robot)/config/base_local_planner_params.yaml" command="load" />
   </node> 
-  -->
 
 </launch>


### PR DESCRIPTION
Corrected amcl file parameters to localize the robot more accurately. following changes have been implemented: 
- increase laser-z-hit and reduce laser-z-rad correspondingly (sum of both values must be 1) improves localization. 
- reduce alpha01 to alpha04 noises from default value to 0.01 increase localization accuracy. Particles of possible locations are closer together. 
- min and max number of particles changed from defaults to the range 100 to 200 gave best results. Notice: when tested min value below  25 the localization was totally wrong.